### PR TITLE
Recursive injection with an example

### DIFF
--- a/example/example/spiders/books_06.py
+++ b/example/example/spiders/books_06.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+"""
+Scrapy spider with reusable components used for two types of pages:
+* Listings page, with the components: book list and pagination
+* Detail book page, with the components: the item itself, the breadcrumbs and
+  the recently viewed list of books
+
+All links to detail book pages are found are followed.
+All links to search result pages are followed as well.
+"""
+import scrapy
+import attr
+
+from scrapy_po import WebPage
+
+
+class ListingsPiece(WebPage):
+    def urls(self):
+        return self.css('.image_container a::attr(href)').getall()
+
+
+class PaginationPiece(WebPage):
+    def urls(self):
+        return self.css('.pager a::attr(href)').getall()
+
+
+class BreadcrumbsPiece(WebPage):
+    def urls(self):
+        return self.css('.breadcrumb a::attr(href)').getall()
+
+
+@attr.s(auto_attribs=True)
+class ListingsPage(WebPage):
+    book_list: ListingsPiece
+    pagination: PaginationPiece
+
+
+@attr.s(auto_attribs=True)
+class BookPage(WebPage):
+    recently_viewed: ListingsPiece
+    breadcrumbs: BreadcrumbsPiece
+
+    def to_item(self):
+        return {
+            'url': self.url,
+            'name': self.css("title::text").get(),
+        }
+
+
+class BooksSpider(scrapy.Spider):
+    name = 'books_06'
+    start_urls = ['http://books.toscrape.com/']
+
+    def parse(self, response, page: ListingsPage):
+        """ Callback for Listings pages """
+        yield from self.follow_listing(response, page.book_list)
+        yield from self.follow_pagination(response, page.pagination)
+
+    def parse_book(self, response, page: BookPage):
+        yield from self.follow_listing(response, page.recently_viewed)
+        yield from self.follow_breadcrumbs(response, page.breadcrumbs)
+        yield page.to_item()
+
+    def follow_listing(self, response, item_list: ListingsPiece):
+        for url in item_list.urls():
+            yield response.follow(url, self.parse_book)
+
+    def follow_pagination(self, response, pagination: PaginationPiece):
+        for url in pagination.urls():
+            yield response.follow(url, self.parse, priority=+10)
+
+    def follow_breadcrumbs(self, response, breadcrumbs: BreadcrumbsPiece):
+        for url in breadcrumbs.urls():
+            yield response.follow(url, self.parse)

--- a/scrapy_po/middleware.py
+++ b/scrapy_po/middleware.py
@@ -39,7 +39,7 @@ class InjectPageObjectsMiddleware:
 
 
 @inlineCallbacks
-def create_page_object(page_cls, response, dependency_graph=[]):
+def create_page_object(page_cls, response, dependency_graph=None):
     """
     Create PageObject instances, resolving all constructor dependencies.
     """
@@ -59,6 +59,7 @@ def create_page_object(page_cls, response, dependency_graph=[]):
 
     # instantiate all arguments
     kwargs = {}
+    dependency_graph = dependency_graph or []
     for argname, cls in kwargs_to_provide.items():
         if cls in dependency_graph:
             raise TypeError("Cyclic dependency found. Dependency graph: %s ",


### PR DESCRIPTION
Having recursive dependency injection can help to create smaller PageObject components that extracts only parts of a page, and then define compounded PageObjects with several of them. See example `books_06`. 

The example of `books_06` presents boilerplate. A lot of `yield from self.` and `response` repeated and repeated. 

@kmike It would be nice if you can have a look and give your opinion about all that. 

I was not able to check if cyclic dependency detection is working
because I failed to create an example. The following fails with the error `NameError: name 'B' is not defined` in method `get_type_hints`:

```py
@attr.s(auto_attribs=True)
class A(WebPage):
    b: 'B'

@attr.s(auto_attribs=True)
class B(WebPage):
    a: A
```
