### PR TITLE
PageComponent introduced

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,7 +40,7 @@ Usage
 First, enable middleware in your settings.py::
 
     DOWNLOADER_MIDDLEWARES = {
-       'scrapy_po.InjectPageObjectsMiddleware': 543,
+       'scrapy_po.InjectionMiddleware': 543,
     }
 
 After that you can write spiders which use page object pattern to separate

--- a/example/example/autoextract.py
+++ b/example/example/autoextract.py
@@ -10,7 +10,7 @@ from twisted.internet.defer import inlineCallbacks, returnValue
 from twisted.internet.threads import deferToThread
 
 from scrapy_po.page_input_providers import PageObjectInputProvider, provides
-from scrapy_po.webpage import PageObject
+from scrapy_po.webpage import Injectable, ItemPage
 
 
 @attr.s(auto_attribs=True)
@@ -38,7 +38,7 @@ def get_autoextract_product(url):
 
 
 @attr.s(auto_attribs=True)
-class ProductPage(PageObject):
+class ProductPage(ItemPage):
     """ Generic product page """
     autoextract_resp: AutoextractProductResponse
 

--- a/example/example/settings.py
+++ b/example/example/settings.py
@@ -53,7 +53,7 @@ ROBOTSTXT_OBEY = True
 # Enable or disable downloader middlewares
 # See https://docs.scrapy.org/en/latest/topics/downloader-middleware.html
 DOWNLOADER_MIDDLEWARES = {
-   'scrapy_po.InjectPageObjectsMiddleware': 543,
+   'scrapy_po.InjectionMiddleware': 543,
 }
 
 # Enable or disable extensions

--- a/example/example/spiders/books_06.py
+++ b/example/example/spiders/books_06.py
@@ -15,31 +15,31 @@ import attr
 from scrapy_po import WebPage, ItemWebPage, Injectable
 
 
-class ListingsComponent(WebPage):
+class ListingsExtractor(WebPage):
     def urls(self):
         return self.css('.image_container a::attr(href)').getall()
 
 
-class PaginationComponent(WebPage):
+class PaginationExtractor(WebPage):
     def urls(self):
         return self.css('.pager a::attr(href)').getall()
 
 
-class BreadcrumbsComponent(WebPage):
+class BreadcrumbsExtractor(WebPage):
     def urls(self):
         return self.css('.breadcrumb a::attr(href)').getall()
 
 
 @attr.s(auto_attribs=True)
 class ListingsPage(Injectable):
-    book_list: ListingsComponent
-    pagination: PaginationComponent
+    book_list: ListingsExtractor
+    pagination: PaginationExtractor
 
 
 @attr.s(auto_attribs=True)
 class BookPage(ItemWebPage):
-    recently_viewed: ListingsComponent
-    breadcrumbs: BreadcrumbsComponent
+    recently_viewed: ListingsExtractor
+    breadcrumbs: BreadcrumbsExtractor
 
     def to_item(self):
         return {
@@ -62,14 +62,14 @@ class BooksSpider(scrapy.Spider):
         yield from self.follow_breadcrumbs(response, page.breadcrumbs)
         yield page.to_item()
 
-    def follow_listing(self, response, item_list: ListingsComponent):
+    def follow_listing(self, response, item_list: ListingsExtractor):
         for url in item_list.urls():
             yield response.follow(url, self.parse_book)
 
-    def follow_pagination(self, response, pagination: PaginationComponent):
+    def follow_pagination(self, response, pagination: PaginationExtractor):
         for url in pagination.urls():
             yield response.follow(url, self.parse, priority=+10)
 
-    def follow_breadcrumbs(self, response, breadcrumbs: BreadcrumbsComponent):
+    def follow_breadcrumbs(self, response, breadcrumbs: BreadcrumbsExtractor):
         for url in breadcrumbs.urls():
             yield response.follow(url, self.parse)

--- a/example/example/spiders/books_06.py
+++ b/example/example/spiders/books_06.py
@@ -12,32 +12,32 @@ All links to search result pages are followed as well.
 import scrapy
 import attr
 
-from scrapy_po import WebPage, ItemPage, PageComponent
+from scrapy_po import WebPage, ItemWebPage, Injectable
 
 
-class ListingsComponent(PageComponent):
+class ListingsComponent(WebPage):
     def urls(self):
         return self.css('.image_container a::attr(href)').getall()
 
 
-class PaginationComponent(PageComponent):
+class PaginationComponent(WebPage):
     def urls(self):
         return self.css('.pager a::attr(href)').getall()
 
 
-class BreadcrumbsComponent(PageComponent):
+class BreadcrumbsComponent(WebPage):
     def urls(self):
         return self.css('.breadcrumb a::attr(href)').getall()
 
 
 @attr.s(auto_attribs=True)
-class ListingsPage(WebPage):
+class ListingsPage(Injectable):
     book_list: ListingsComponent
     pagination: PaginationComponent
 
 
 @attr.s(auto_attribs=True)
-class BookPage(WebPage, ItemPage):
+class BookPage(ItemWebPage):
     recently_viewed: ListingsComponent
     breadcrumbs: BreadcrumbsComponent
 

--- a/example/example/spiders/books_06.py
+++ b/example/example/spiders/books_06.py
@@ -13,33 +13,34 @@ import scrapy
 import attr
 
 from scrapy_po import WebPage, ItemPage
+from scrapy_po.webpage import PageComponent
 
 
-class ListingsPiece(WebPage):
+class ListingsComponent(PageComponent):
     def urls(self):
         return self.css('.image_container a::attr(href)').getall()
 
 
-class PaginationPiece(WebPage):
+class PaginationComponent(PageComponent):
     def urls(self):
         return self.css('.pager a::attr(href)').getall()
 
 
-class BreadcrumbsPiece(WebPage):
+class BreadcrumbsComponent(PageComponent):
     def urls(self):
         return self.css('.breadcrumb a::attr(href)').getall()
 
 
 @attr.s(auto_attribs=True)
 class ListingsPage(WebPage):
-    book_list: ListingsPiece
-    pagination: PaginationPiece
+    book_list: ListingsComponent
+    pagination: PaginationComponent
 
 
 @attr.s(auto_attribs=True)
 class BookPage(WebPage, ItemPage):
-    recently_viewed: ListingsPiece
-    breadcrumbs: BreadcrumbsPiece
+    recently_viewed: ListingsComponent
+    breadcrumbs: BreadcrumbsComponent
 
     def to_item(self):
         return {
@@ -62,14 +63,14 @@ class BooksSpider(scrapy.Spider):
         yield from self.follow_breadcrumbs(response, page.breadcrumbs)
         yield page.to_item()
 
-    def follow_listing(self, response, item_list: ListingsPiece):
+    def follow_listing(self, response, item_list: ListingsComponent):
         for url in item_list.urls():
             yield response.follow(url, self.parse_book)
 
-    def follow_pagination(self, response, pagination: PaginationPiece):
+    def follow_pagination(self, response, pagination: PaginationComponent):
         for url in pagination.urls():
             yield response.follow(url, self.parse, priority=+10)
 
-    def follow_breadcrumbs(self, response, breadcrumbs: BreadcrumbsPiece):
+    def follow_breadcrumbs(self, response, breadcrumbs: BreadcrumbsComponent):
         for url in breadcrumbs.urls():
             yield response.follow(url, self.parse)

--- a/example/example/spiders/books_06.py
+++ b/example/example/spiders/books_06.py
@@ -12,8 +12,7 @@ All links to search result pages are followed as well.
 import scrapy
 import attr
 
-from scrapy_po import WebPage, ItemPage
-from scrapy_po.webpage import PageComponent
+from scrapy_po import WebPage, ItemPage, PageComponent
 
 
 class ListingsComponent(PageComponent):

--- a/scrapy_po/__init__.py
+++ b/scrapy_po/__init__.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 from .middleware import InjectPageObjectsMiddleware
-from .webpage import PageObject, WebPage, ItemPage, callback_for
+from .webpage import PageObject, WebPage, ItemPage, PageComponent, callback_for

--- a/scrapy_po/__init__.py
+++ b/scrapy_po/__init__.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
-from .middleware import InjectPageObjectsMiddleware
-from .webpage import PageObject, WebPage, ItemPage, PageComponent, callback_for
+from .middleware import InjectionMiddleware
+from .webpage import Injectable, WebPage, ItemPage, ItemWebPage, callback_for

--- a/scrapy_po/middleware.py
+++ b/scrapy_po/middleware.py
@@ -5,14 +5,14 @@ import andi
 from twisted.internet.defer import inlineCallbacks, returnValue, maybeDeferred
 from scrapy import Request
 
-from .webpage import PageObject
+from .webpage import Injectable
 from .utils import get_callback
 from .page_input_providers import providers
 
 
-class InjectPageObjectsMiddleware:
+class InjectionMiddleware:
     """
-    This downloader middleware instantiates all PageObject subclasses declared
+    This downloader middleware instantiates all Injectable subclasses declared
     as request callback arguments and any other parameter with a provider
     for its type. Otherwise this middleware doesn't populate request.cb_kwargs
     for this argument.
@@ -57,10 +57,10 @@ def build_providers(response) -> Dict[type, Callable]:
 
 
 def can_provide_fn(providers):
-    """ A type is providable if it is a ``PageObject`` or if there exists
+    """ A type is providable if it is ``Injectable`` or if there exists
     a provider for it. Also None is providable by default. """
     def fn(argument_type):
         return (argument_type == type(None) or
                 argument_type in providers or
-                issubclass(argument_type, PageObject))
+                issubclass(argument_type, Injectable))
     return fn

--- a/scrapy_po/webpage.py
+++ b/scrapy_po/webpage.py
@@ -7,17 +7,18 @@ import parsel
 from .page_inputs import ResponseData
 
 
-class PageObject(abc.ABC):
+class Injectable(abc.ABC):
     """
-    All web page objects should inherit from this class.
-    It is a marker for a middleware to pick anargument and populate it.
+    Injectable objects are automatically built and passed as arguments to
+    callbacks that requires them. The ``InjectionMiddleware`` take care of it.
 
-    Instead of inheriting you can also use ``PageObject.register(MyWebPage)``.
+    Instead of inheriting you can also use ``Injectable.register(MyWebPage)``.
+    ``register`` can also be used as a decorator.
     """
     pass
 
 
-class ItemPage(PageObject):
+class ItemPage(Injectable):
     """ Page Object which requires to_item method to be implemented. """
     @abc.abstractmethod
     def to_item(self):
@@ -54,7 +55,7 @@ class ResponseShortcutsMixin:
 
 
 @attr.s(auto_attribs=True)
-class WebPage(PageObject, ResponseShortcutsMixin):
+class WebPage(Injectable, ResponseShortcutsMixin):
     """
     Default WebPage class. It uses basic response data (html, url),
     and provides xpath / css shortcuts.
@@ -67,17 +68,11 @@ class WebPage(PageObject, ResponseShortcutsMixin):
 
 
 @attr.s(auto_attribs=True)
-class PageComponent(PageObject, ResponseShortcutsMixin):
+class ItemWebPage(WebPage, ItemPage):
     """
-    Use it for implementing extractors for particular components of the
-    page (i.e. breadcrumbs) that can be reused across different page objects.
-
-    For example, a book page object can rely on breadcrumbs page component
-    to extract the book category and also a book listings page object could
-    rely in this component to extract the category a listings page
-    belongs to.
+    ``WebPage`` that implements the ``to_item`` method.
     """
-    response: ResponseData
+    pass
 
 
 def callback_for(page_cls):

--- a/scrapy_po/webpage.py
+++ b/scrapy_po/webpage.py
@@ -66,6 +66,20 @@ class WebPage(PageObject, ResponseShortcutsMixin):
     response: ResponseData
 
 
+@attr.s(auto_attribs=True)
+class PageComponent(PageObject, ResponseShortcutsMixin):
+    """
+    Use it for implementing extractors for particular components of the
+    page (i.e. breadcrumbs) that can be reused across different page objects.
+
+    For example, a book page object can rely on breadcrumbs page component
+    to extract the book category and also a book listings page object could
+    rely in this component to extract the category a listings page
+    belongs to.
+    """
+    response: ResponseData
+
+
 def callback_for(page_cls):
     """ Helper for defining callbacks for pages with to_item methods """
     def parse(*args, page: page_cls):

--- a/scrapy_po/webpage.py
+++ b/scrapy_po/webpage.py
@@ -13,7 +13,7 @@ class Injectable(abc.ABC):
     callbacks that requires them. The ``InjectionMiddleware`` take care of it.
 
     Instead of inheriting you can also use ``Injectable.register(MyWebPage)``.
-    ``register`` can also be used as a decorator.
+    ``Injectable.register`` can also be used as a decorator.
     """
     pass
 


### PR DESCRIPTION
Question: is the name too long (`PageComponent`)? 

Alternatives::
* `Component`
* `PagePart`
* `PagePiece`

Note this is based on top of https://github.com/scrapinghub/scrapy-po/pull/5 that is in the review process. 