### PR TITLE
Skipping downloads when they're not necessary to execute parsers

### DIFF
--- a/example/example/autoextract.py
+++ b/example/example/autoextract.py
@@ -10,7 +10,8 @@ from twisted.internet.defer import inlineCallbacks, returnValue
 from twisted.internet.threads import deferToThread
 
 from scrapy_po.page_input_providers import PageObjectInputProvider, provides
-from scrapy_po.webpage import Injectable, ItemPage
+from scrapy_po.webpage import ItemPage
+from scrapy_po.utils import DummyResponse
 
 
 @attr.s(auto_attribs=True)
@@ -21,6 +22,10 @@ class AutoextractProductResponse:
 
 @provides(AutoextractProductResponse)
 class AutoextractProductProvider(PageObjectInputProvider):
+
+    def __init__(self, response: DummyResponse):
+        self.response = response
+
     @inlineCallbacks
     def __call__(self):
         data = (yield get_autoextract_product(self.response.url))

--- a/example/example/autoextract.py
+++ b/example/example/autoextract.py
@@ -35,7 +35,6 @@ class AutoextractProductProvider(PageObjectInputProvider):
 
 @inlineCallbacks
 def get_autoextract_product(url):
-    raise returnValue({'product': {'url': url, 'name': url}})
     # fixme: use async
     # fixme: rate limits?
     from autoextract.sync import request_batch

--- a/example/example/autoextract.py
+++ b/example/example/autoextract.py
@@ -30,6 +30,7 @@ class AutoextractProductProvider(PageObjectInputProvider):
 
 @inlineCallbacks
 def get_autoextract_product(url):
+    raise returnValue({'product': {'url': url, 'name': url}})
     # fixme: use async
     # fixme: rate limits?
     from autoextract.sync import request_batch

--- a/example/example/spiders/books_05_1.py
+++ b/example/example/spiders/books_05_1.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+"""
+Scrapy spider which uses Page Objects both for crawling and extraction.
+You can mix various page types freely.
+"""
+from typing import Optional
+
+import scrapy
+
+from scrapy_po import WebPage
+from scrapy_po.utils import DummyResponse
+from example.autoextract import ProductPage
+
+
+class BookListPage(WebPage):
+    def product_urls(self):
+        return self.css('.image_container a::attr(href)').getall()
+
+
+class BookPage(ProductPage):
+    def to_item(self):
+        # post-processing example: return only 2 fields
+        book = super().to_item()
+        return {
+            'url': book['url'],
+            'name': book['name'],
+        }
+
+
+class BooksSpider(scrapy.Spider):
+    name = 'books_05_1'
+    start_urls = ['http://books.toscrape.com/']
+
+    def parse(self, response, page: BookListPage):
+        for url in page.product_urls():
+            yield response.follow(url, self.parse_book)
+
+    # Bypassing download using DummyResponse since we'll be using AutoExtract.
+    def parse_book(self, response: DummyResponse, page: BookPage):
+        # you can also post-process data in a spider
+        book = page.to_item()
+        book['title'] = book.pop('name')
+        yield book

--- a/example/example/spiders/books_05_1.py
+++ b/example/example/spiders/books_05_1.py
@@ -2,8 +2,15 @@
 """
 Scrapy spider which uses Page Objects both for crawling and extraction.
 You can mix various page types freely.
+
+This example shows how to skip request downloads using DummyResponse type
+annotations. You should use this type annotation in your callback method
+and make sure that all of your providers don't require the use of a regular
+Response injection.
+
+Check the ``example.autoextract.AutoextractProductProvider.__init__`` method
+and the ``BooksSpider.parse_book`` callback for implementation details.
 """
-from typing import Optional
 
 import scrapy
 

--- a/scrapy_po/middleware.py
+++ b/scrapy_po/middleware.py
@@ -1,17 +1,12 @@
 # -*- coding: utf-8 -*-
-import inspect
-from typing import Dict, Callable, Type, Tuple
 
 from scrapy.utils.defer import maybeDeferred_coro
 
 import andi
 from twisted.internet.defer import inlineCallbacks, returnValue
 from scrapy import Request
-from scrapy.http import Response, TextResponse
 
-from .webpage import Injectable
-from .utils import get_callback, DummyResponse
-from .page_input_providers import providers
+from scrapy_po import utils
 
 
 class InjectionMiddleware:
@@ -23,31 +18,6 @@ class InjectionMiddleware:
 
     XXX: should it really be a downloader middleware?
     """
-    def is_response_going_to_be_used(self, request, spider):
-        """Check whether the request's response is going to be used."""
-        callback = get_callback(request, spider)
-        plan, _ = build_plan(callback, {})
-        for obj, _ in plan:
-            spec = inspect.getfullargspec(obj)
-            if 'response' not in spec.args:
-                # There's not argument named response, let's continue.
-                continue
-
-            if 'response' not in spec.annotations:
-                # There's no type annotation for the response argument,
-                # so we cannot infer that it's not going to be used.
-                return True
-
-            if not issubclass(spec.annotations['response'], DummyResponse):
-                # The response is not a DummyResponse, so it's probably used.
-                return True
-
-        # The parser method is using a DummyResponse as a type annotation.
-        # This suggests that the response might not get used.
-        # Also, we were not able to find any evidence that the response is
-        # going to be used by any injected Page Object.
-        return False
-
     def process_request(self, request: Request, spider):
         """Check if the request is needed and if the download can be skipped.
 
@@ -55,23 +25,23 @@ class InjectionMiddleware:
         by its designated parser or an injected Page Object.
 
         If we evaluate that the request could be ignored, we return a
-        DummyResponse object linked to the original Request instance.
+        utils.DummyResponse object linked to the original Request instance.
 
         With this behavior we're able to optimize spider executions avoid
         having to download URLs twice or when they're not needed, for example,
         when a Page Object relies only on a third-party API like AutoExtract.
         """
-        if self.is_response_going_to_be_used(request, spider):
+        if utils.is_response_going_to_be_used(request, spider):
             return
 
         spider.logger.debug(f'Skipping download of {request}')
-        return DummyResponse(url=request.url, request=request)
+        return utils.DummyResponse(url=request.url, request=request)
 
     @inlineCallbacks
     def process_response(self, request: Request, response, spider):
         # find out the dependencies
-        callback = get_callback(request, spider)
-        plan, provider_instances = build_plan(callback, response)
+        callback = utils.get_callback(request, spider)
+        plan, provider_instances = utils.build_plan(callback, response)
 
         # Build all instances declared as dependencies
         instances = yield from build_instances(
@@ -87,18 +57,6 @@ class InjectionMiddleware:
         raise returnValue(response)
 
 
-def build_plan(callback, response
-               ) -> Tuple[andi.Plan, Dict[Type, Callable]]:
-    """ Build a plan for the injection in the callback """
-    provider_instances = build_providers(response)
-    plan = andi.plan(
-        callback,
-        is_injectable=is_injectable,
-        externally_provided=provider_instances.keys()
-    )
-    return plan, provider_instances
-
-
 @inlineCallbacks
 def build_instances(plan: andi.Plan, providers):
     """ Build the instances dict from a plan """
@@ -109,17 +67,3 @@ def build_instances(plan: andi.Plan, providers):
         else:
             instances[cls] = cls(**kwargs_spec.kwargs(instances))
     raise returnValue(instances)
-
-
-def build_providers(response) -> Dict[Type, Callable]:
-    # find out what resources are available
-    return {cls: provider(response)
-            for cls, provider in providers.items()}
-
-
-def is_injectable(argument_type: Callable) -> bool:
-    """
-    A type is injectable if inherits from ``Injectable``.
-    """
-    return (isinstance(argument_type, type) and
-            issubclass(argument_type, Injectable))

--- a/scrapy_po/middleware.py
+++ b/scrapy_po/middleware.py
@@ -11,7 +11,7 @@ from scrapy.http import Response, TextResponse
 
 from .webpage import Injectable
 from .utils import get_callback, DummyResponse
-from.page_inputs import ResponseData
+from .page_inputs import ResponseData
 from .page_input_providers import providers
 
 

--- a/scrapy_po/middleware.py
+++ b/scrapy_po/middleware.py
@@ -11,7 +11,6 @@ from scrapy.http import Response, TextResponse
 
 from .webpage import Injectable
 from .utils import get_callback, DummyResponse
-from .page_inputs import ResponseData
 from .page_input_providers import providers
 
 

--- a/scrapy_po/middleware.py
+++ b/scrapy_po/middleware.py
@@ -1,8 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from scrapy.utils.defer import maybeDeferred_coro
-
-import andi
 from twisted.internet.defer import inlineCallbacks, returnValue
 from scrapy import Request
 
@@ -44,7 +41,7 @@ class InjectionMiddleware:
         plan, provider_instances = utils.build_plan(callback, response)
 
         # Build all instances declared as dependencies
-        instances = yield from build_instances(
+        instances = yield from utils.build_instances(
             plan.dependencies, provider_instances)
 
         # Fill the callback arguments with the created instances
@@ -55,15 +52,3 @@ class InjectionMiddleware:
             # TODO: check if all arguments are fulfilled somehow?
 
         raise returnValue(response)
-
-
-@inlineCallbacks
-def build_instances(plan: andi.Plan, providers):
-    """ Build the instances dict from a plan """
-    instances = {}
-    for cls, kwargs_spec in plan:
-        if cls in providers:
-            instances[cls] = yield maybeDeferred_coro(providers[cls])
-        else:
-            instances[cls] = cls(**kwargs_spec.kwargs(instances))
-    raise returnValue(instances)

--- a/scrapy_po/page_input_providers.py
+++ b/scrapy_po/page_input_providers.py
@@ -2,16 +2,15 @@
 import abc
 
 from scrapy.http.response import Response
-from .page_inputs import ResponseData
+from scrapy_po.page_inputs import ResponseData
 
 # fixme: refactor _providers / provides / register,  make a nicer API
 providers = {}
 
 
 def register(provider, cls):
-    """
-    Register a class as providing a certain page object input
-    of type ``cls``
+    """Register a class as providing a certain page object input
+    of type ``cls``.
     """
     providers[cls] = provider
 

--- a/scrapy_po/page_input_providers.py
+++ b/scrapy_po/page_input_providers.py
@@ -23,8 +23,6 @@ def provides(cls):
 
 
 class PageObjectInputProvider(abc.ABC):
-    def __init__(self, response: Response):
-        self.response = response
 
     @abc.abstractmethod
     def __call__(self):
@@ -33,6 +31,10 @@ class PageObjectInputProvider(abc.ABC):
 
 @provides(ResponseData)
 class ResponseDataProvider(PageObjectInputProvider):
+
+    def __init__(self, response: Response):
+        self.response = response
+
     def __call__(self):
         return ResponseData(
             url=self.response.url,

--- a/scrapy_po/utils.py
+++ b/scrapy_po/utils.py
@@ -1,5 +1,12 @@
 # -*- coding: utf-8 -*-
+import inspect
+from typing import Tuple, Dict, Type, Callable
+
+import andi
 from scrapy.http import Response
+
+from scrapy_po.webpage import Injectable
+from scrapy_po.page_input_providers import providers
 
 
 def get_callback(request, spider):
@@ -13,3 +20,56 @@ class DummyResponse(Response):
 
     def __init__(self, url, request=None):
         super(DummyResponse, self).__init__(url=url, request=request)
+
+
+def is_response_going_to_be_used(request, spider):
+    """Check whether the request's response is going to be used."""
+    callback = get_callback(request, spider)
+    plan, _ = build_plan(callback, {})
+
+    for obj, _ in plan:
+        spec = inspect.getfullargspec(obj)
+        if 'response' not in spec.args:
+            # There's not argument named response, let's continue.
+            continue
+
+        if 'response' not in spec.annotations:
+            # There's no type annotation for the response argument,
+            # so we cannot infer that it's not going to be used.
+            return True
+
+        if not issubclass(spec.annotations['response'], DummyResponse):
+            # The response is not a DummyResponse, so it's probably used.
+            return True
+
+    # The parser method is using a DummyResponse as a type annotation.
+    # This suggests that the response might not get used.
+    # Also, we were not able to find any evidence that the response is
+    # going to be used by any injected Page Object.
+    return False
+
+
+def build_plan(callback, response
+               ) -> Tuple[andi.Plan, Dict[Type, Callable]]:
+    """ Build a plan for the injection in the callback """
+    provider_instances = build_providers(response)
+    plan = andi.plan(
+        callback,
+        is_injectable=is_injectable,
+        externally_provided=provider_instances.keys()
+    )
+    return plan, provider_instances
+
+
+def build_providers(response) -> Dict[Type, Callable]:
+    # find out what resources are available
+    return {cls: provider(response)
+            for cls, provider in providers.items()}
+
+
+def is_injectable(argument_type: Callable) -> bool:
+    """
+    A type is injectable if inherits from ``Injectable``.
+    """
+    return (isinstance(argument_type, type) and
+            issubclass(argument_type, Injectable))

--- a/scrapy_po/utils.py
+++ b/scrapy_po/utils.py
@@ -1,7 +1,15 @@
 # -*- coding: utf-8 -*-
+from scrapy.http import Response
+
 
 def get_callback(request, spider):
     """ Get request.callback of a scrapy.Request, as a callable """
     if request.callback is None:
         return getattr(spider, 'parse')
     return request.callback
+
+
+class DummyResponse(Response):
+
+    def __init__(self, url, request=None):
+        super(DummyResponse, self).__init__(url=url, request=request)

--- a/scrapy_po/utils.py
+++ b/scrapy_po/utils.py
@@ -72,7 +72,7 @@ def is_response_going_to_be_used(request, spider):
     if is_callback_using_response(callback):
         return True
 
-    plan, _ = build_plan(callback, {})
+    plan, _ = build_plan(callback, None)
     for provider in get_providers(plan):
         if is_provider_using_response(provider):
             return True

--- a/scrapy_po/utils.py
+++ b/scrapy_po/utils.py
@@ -103,8 +103,15 @@ def build_plan(callback, response
 
 def build_providers(response) -> Dict[Type, Callable]:
     # find out what resources are available
-    return {cls: provider(response)
-            for cls, provider in providers.items()}
+    result = {}
+    for cls, provider in providers.items():
+        spec = inspect.getfullargspec(provider)
+        if spec.args:
+            result[cls] = provider(response)
+        else:
+            result[cls] = provider()
+
+    return result
 
 
 def is_injectable(argument_type: Callable) -> bool:

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -112,6 +112,9 @@ class ProvidedAsyncTest:
 @provides(ProvidedAsyncTest)
 class ResponseDataProvider(PageObjectInputProvider):
 
+    def __init__(self, response: scrapy.http.Response):
+        self.response = response
+
     @inlineCallbacks
     def __call__(self):
         five = yield deferToThread(lambda: 5)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -21,6 +21,12 @@ class DummyProductResponse:
     data: Dict[str, Any]
 
 
+@attr.s(auto_attribs=True)
+class FakeProductResponse:
+
+    data: Dict[str, Any]
+
+
 @provides(DummyProductResponse)
 class DummyProductProvider(PageObjectInputProvider):
 
@@ -30,7 +36,20 @@ class DummyProductProvider(PageObjectInputProvider):
     def __call__(self):
         data = {
             'product': {
-                'url': 'http://example.com',
+                'url': self.response.url,
+                'name': 'Sample',
+            },
+        }
+        return DummyProductResponse(data=data)
+
+
+@provides(FakeProductResponse)
+class FakeProductProvider(PageObjectInputProvider):
+
+    def __call__(self):
+        data = {
+            'product': {
+                'url': 'http://example.com/sample',
                 'name': 'Sample',
             },
         }
@@ -41,6 +60,20 @@ class DummyProductProvider(PageObjectInputProvider):
 class DummyProductPage(ItemPage):
 
     response: DummyProductResponse
+
+    @property
+    def url(self):
+        return self.response.data['product']['url']
+
+    def to_item(self):
+        product = self.response.data['product']
+        return product
+
+
+@attr.s(auto_attribs=True)
+class FakeProductPage(ItemPage):
+
+    response: FakeProductResponse
 
     @property
     def url(self):
@@ -82,6 +115,12 @@ class MySpider(scrapy.Spider):
         pass
 
     def parse8(self, response: DummyResponse, book_page: DummyProductPage):
+        pass
+
+    def parse9(self, response, book_page: FakeProductPage):
+        pass
+
+    def parse10(self, response: DummyResponse, book_page: FakeProductPage):
         pass
 
 
@@ -126,4 +165,10 @@ def test_is_response_going_to_be_used():
     assert is_response_going_to_be_used(request, spider) is True
 
     request = scrapy.Request("http://example.com", callback=spider.parse8)
+    assert is_response_going_to_be_used(request, spider) is False
+
+    request = scrapy.Request("http://example.com", callback=spider.parse9)
+    assert is_response_going_to_be_used(request, spider) is True
+
+    request = scrapy.Request("http://example.com", callback=spider.parse10)
     assert is_response_going_to_be_used(request, spider) is False

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,10 @@
 # -*- coding: utf-8 -*-
 import scrapy
-from scrapy_po.utils import get_callback
+from scrapy_po.utils import (
+    get_callback,
+    is_response_going_to_be_used,
+    DummyResponse,
+)
 
 
 class MySpider(scrapy.Spider):
@@ -10,6 +14,9 @@ class MySpider(scrapy.Spider):
         pass
 
     def parse2(self, response):
+        pass
+
+    def parse3(self, response: DummyResponse):
         pass
 
 
@@ -27,3 +34,13 @@ def test_get_callback():
 
     req = scrapy.Request("http://example.com", cb)
     assert get_callback(req, spider) == cb
+
+
+def test_is_response_going_to_be_used():
+    spider = MySpider()
+
+    request = scrapy.Request("http://example.com")
+    assert is_response_going_to_be_used(request, spider) is True
+
+    request = scrapy.Request("http://example.com", callback=spider.parse3)
+    assert is_response_going_to_be_used(request, spider) is False

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -69,6 +69,12 @@ class TextProductProvider(ResponseDataProvider):
         self.response = response
 
 
+class StringProductProvider(ResponseDataProvider):
+
+    def __init__(self, response: str):
+        self.response = response
+
+
 @attr.s(auto_attribs=True)
 class DummyProductPage(ItemPage):
 
@@ -165,6 +171,7 @@ def test_is_provider_using_response():
     assert is_provider_using_response(TextProductProvider) is True
     assert is_provider_using_response(DummyProductProvider) is False
     assert is_provider_using_response(FakeProductProvider) is False
+    assert is_provider_using_response(StringProductProvider) is False
 
 
 def test_is_callback_using_response():

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -27,7 +27,7 @@ class HtmlResource(Resource):
 
 @inlineCallbacks
 def crawl_items(spider_cls, resource_cls, settings, spider_kwargs=None):
-    """ Use spider_cls to crawl resource_cls. URL of the resource is passed
+    """Use spider_cls to crawl resource_cls. URL of the resource is passed
     to the spider as ``url`` argument.
     Return ``(items, resource_url, crawler)`` tuple.
     """
@@ -42,7 +42,7 @@ def crawl_items(spider_cls, resource_cls, settings, spider_kwargs=None):
 
 @inlineCallbacks
 def crawl_single_item(spider_cls, resource_cls, settings, spider_kwargs=None):
-    """ Run a spider where a single item is expected. Use in combination with
+    """Run a spider where a single item is expected. Use in combination with
     ``capture_capture_exceptions`` and ``CollectorPipeline``
     """
     items, url, crawler = yield crawl_items(spider_cls, resource_cls, settings,


### PR DESCRIPTION
This is done by inspecting parsers and injectable dependencies.
We search for type annotations and the use of DummyRequests.